### PR TITLE
Invert the cursor blinking phase to match other editors

### DIFF
--- a/textRevealer.css
+++ b/textRevealer.css
@@ -40,8 +40,8 @@ body {
 }
 
 @keyframes blink {
-  from { background-color: rgba(0, 0, 0, 0); }
-  to { background-color: rgba(0, 0, 0, .8); }
+  from { background-color: rgba(0, 0, 0, .8); }
+  to { background-color: rgba(0, 0, 0, 0); }
 }
 
 .tag { display: inline-block; }
@@ -67,7 +67,7 @@ body {
 }
 
 .tag.-SYMBOL { opacity: .5; }
-  
+
 .tag.-numsign {
   font-size: 2em;
   font-weight: 900;
@@ -98,7 +98,7 @@ body {
 .tag.-cjkdq, .tag.-cjkdq-start, .tag.-cjkdq-end {
   font-family: serif;
 }
-  
+
 .tag.-grave, .tag.-grave-start, .tag.-grave-end {
   font-family: monospace;
   font-size: inherit;


### PR DESCRIPTION
The current behavior is that, the cursor starts in transparent, fades in to opaque, and fades out. Because the animation is replayed from start each time the viewport changes, it is hard to track the cursor position during typing. This PR inverts that: Starts in opaque and fades out. Also, the patched behavior matches other text editors with a blinking cursor (e.g. Sublime Text, VS Code, or other contenteditable elements in Chrome).